### PR TITLE
Feat: Add benchmark tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+go.work
+vendor

--- a/algorithm.go
+++ b/algorithm.go
@@ -38,6 +38,14 @@ func init() {
 
 // AlgorithmLookup is used to get a previously registered [Algorithm].
 func AlgorithmLookup(name string) (Algorithm, error) {
+	// skip the lock for registered algorithms
+	switch name {
+	case "sha256":
+		return SHA256, nil
+	case "sha512":
+		return SHA512, nil
+	}
+
 	algorithmsMu.RLock()
 	defer algorithmsMu.RUnlock()
 

--- a/digest.go
+++ b/digest.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"io"
 	"regexp"
+	"strings"
 )
 
 // Digest is the combination of an algorithm and the encoded hash value.
@@ -76,20 +77,20 @@ func Parse(s string) (Digest, error) {
 	if s == "" {
 		return Digest{}, nil
 	}
-	parts := DigestRegexpParts.FindStringSubmatch(s)
-	if len(parts) != 3 {
+	algPart, encPart, ok := strings.Cut(s, ":")
+	if !ok {
 		return Digest{}, fmt.Errorf("%w: %s", ErrDigestInvalid, s)
 	}
-	alg, err := AlgorithmLookup(parts[1])
+	alg, err := AlgorithmLookup(algPart)
 	if err != nil {
 		return Digest{}, err
 	}
-	if alg.enc == nil || !alg.enc.Validate(parts[2]) {
-		return Digest{}, fmt.Errorf("%w: %s", ErrEncodingInvalid, parts[2])
+	if alg.enc == nil || !alg.enc.Validate(encPart) {
+		return Digest{}, fmt.Errorf("%w: %s", ErrEncodingInvalid, encPart)
 	}
 	return Digest{
 		alg: alg,
-		enc: parts[2],
+		enc: encPart,
 	}, nil
 }
 

--- a/digest_test.go
+++ b/digest_test.go
@@ -197,7 +197,7 @@ func TestParse(t *testing.T) {
 		{
 			name: "invalid-hex",
 			s:    "sha256:e3b0c4*298fc1c149afb@4c8996fb92427^e41e4649b934c$495991b7852b85!",
-			err:  ErrDigestInvalid,
+			err:  ErrEncodingInvalid,
 		},
 		{
 			name: "unknown-alg",

--- a/encoding.go
+++ b/encoding.go
@@ -2,7 +2,6 @@ package digest
 
 import (
 	"fmt"
-	"regexp"
 )
 
 // Encoder is used to generate or verify the encoded portion of a digest for a given algorithm.
@@ -16,8 +15,6 @@ type EncodeHex struct {
 	Len int // Len is the length of the encoded text, which is 2x the hash sum length.
 }
 
-var hexRe = regexp.MustCompile(`^[0-9a-f]*$`)
-
 // Encode outputs the encoded string for the hash sum.
 func (e EncodeHex) Encode(p []byte) (string, error) {
 	if len(p)*2 != e.Len {
@@ -27,11 +24,20 @@ func (e EncodeHex) Encode(p []byte) (string, error) {
 }
 
 // Validate verifies the string matches the encoded requirements.
-// The string must match the regexp "[0-9a-f]*".
+// The string must only contain hex characters 0-9 and a-f (lower case).
 // The length must match the Len value of EncodeHex.
 func (e EncodeHex) Validate(s string) bool {
-	if len(s) == e.Len && hexRe.MatchString(s) {
+	if len(s) == e.Len && isHex(s) {
 		return true
 	}
 	return false
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		if (r < 'a' || r > 'f') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }

--- a/testing/benchmark_test.go
+++ b/testing/benchmark_test.go
@@ -1,0 +1,171 @@
+package testing
+
+import (
+	"encoding/json"
+	"testing"
+
+	json2 "github.com/go-json-experiment/json"
+	upstream "github.com/opencontainers/go-digest"
+
+	digest "github.com/sudo-bmitch/oci-digest"
+)
+
+func BenchmarkFromBytes(b *testing.B) {
+	exampleBytes := []byte("hash me")
+	b.Run("digest", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = digest.FromBytes(exampleBytes)
+		}
+	})
+	b.Run("upstream", func(b *testing.B) {
+		for b.Loop() {
+			_ = upstream.FromBytes(exampleBytes)
+		}
+	})
+}
+
+func BenchmarkParse(b *testing.B) {
+	dig, err := digest.FromString("hello world")
+	if err != nil {
+		b.Fatalf("failed to setup digest from string: %v", err)
+	}
+	exampleDig := dig.String()
+	b.Run("digest", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = digest.Parse(exampleDig)
+		}
+	})
+	b.Run("upstream", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = upstream.Parse(exampleDig)
+		}
+	})
+}
+
+func BenchmarkDigester(b *testing.B) {
+	exampleBytes := []byte("hash me")
+	b.Run("digest", func(b *testing.B) {
+		for b.Loop() {
+			d, err := digest.Canonical.Digester()
+			if err != nil {
+				b.Fatalf("failed to create digester: %v", err)
+			}
+			_, err = d.Write(exampleBytes)
+			if err != nil {
+				b.Fatalf("failed to write to digester: %v", err)
+			}
+			_, _ = d.Digest()
+		}
+	})
+	b.Run("upstream", func(b *testing.B) {
+		for b.Loop() {
+			d := upstream.Canonical.Digester()
+			h := d.Hash()
+			_, err := h.Write(exampleBytes)
+			if err != nil {
+				b.Fatalf("failed to write to digester: %v", err)
+			}
+			_ = d.Digest()
+		}
+	})
+}
+
+func BenchmarkJSON(b *testing.B) {
+	exampleStrings := []string{"hello", "world", "foo", "bar", "buzz", "baz", "test", "data", "random", "list"}
+	exampleDigests := make([]digest.Digest, len(exampleStrings))
+	exampleUpstream := make([]upstream.Digest, len(exampleStrings))
+	var err error
+	for i, s := range exampleStrings {
+		exampleDigests[i], err = digest.FromString(s)
+		if err != nil {
+			b.Fatalf("failed to setup example digest %d: %v", i, err)
+		}
+		exampleUpstream[i] = upstream.FromString(s)
+	}
+	exampleJSON, err := json.Marshal(exampleDigests)
+	if err != nil {
+		b.Fatalf("failed to marshal json: %v", err)
+	}
+	b.Run("digest-marshal-v1", func(b *testing.B) {
+		for b.Loop() {
+			_, err := json.Marshal(exampleDigests)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("upstream-marshal-v1", func(b *testing.B) {
+		for b.Loop() {
+			_, err := json.Marshal(exampleUpstream)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("digest-marshal-v2", func(b *testing.B) {
+		for b.Loop() {
+			_, err := json2.Marshal(exampleDigests)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("upstream-marshal-v2", func(b *testing.B) {
+		for b.Loop() {
+			_, err := json2.Marshal(exampleUpstream)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("digest-unmarshal-v1", func(b *testing.B) {
+		for b.Loop() {
+			out := []digest.Digest{}
+			err = json.Unmarshal(exampleJSON, &out)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("upstream-unmarshal-v1", func(b *testing.B) {
+		for b.Loop() {
+			out := []upstream.Digest{}
+			err = json.Unmarshal(exampleJSON, &out)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+			// validation is separate from the unmarshaling in upstream
+			for _, d := range out {
+				err = d.Validate()
+				if err != nil {
+					b.Fatalf("failed to validate: %v", err)
+				}
+			}
+		}
+	})
+	b.Run("digest-unmarshal-v2", func(b *testing.B) {
+		for b.Loop() {
+			out := []digest.Digest{}
+			err = json2.Unmarshal(exampleJSON, &out)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+		}
+	})
+	b.Run("upstream-unmarshal-v2", func(b *testing.B) {
+		for b.Loop() {
+			out := []upstream.Digest{}
+			err = json2.Unmarshal(exampleJSON, &out)
+			if err != nil {
+				b.Fatalf("failed to unmarshal json: %v", err)
+			}
+			// validation is separate from the unmarshaling in upstream
+			for _, d := range out {
+				err = d.Validate()
+				if err != nil {
+					b.Fatalf("failed to validate: %v", err)
+				}
+			}
+		}
+	})
+}

--- a/testing/go.mod
+++ b/testing/go.mod
@@ -1,0 +1,9 @@
+module github.com/sudo-bmitch/oci-digest/testing
+
+go 1.24.3
+
+require (
+	github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1
+	github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b
+	github.com/sudo-bmitch/oci-digest v0.0.0-20250515204613-a89494cee0f6
+)

--- a/testing/go.sum
+++ b/testing/go.sum
@@ -1,0 +1,8 @@
+github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1 h1:+VexzzkMLb1tnvpuQdGT/DicIRW7MN8ozsXqBMgp0Hk=
+github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b h1:0XWQwEHfTQ7zrjFjaOnKrU8z9UVdv1A4uGU39phmwNI=
+github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
+github.com/sudo-bmitch/oci-digest v0.0.0-20250515204613-a89494cee0f6 h1:8gjhX/jzKrABarH3SWVPLFTgTwWI/AQa/FU2ORMvxZQ=
+github.com/sudo-bmitch/oci-digest v0.0.0-20250515204613-a89494cee0f6/go.mod h1:TawA3vghusurkiqWFZ07e3ynLpKcZXaH/RkohKCxPms=


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This adds some benchmark tests to compare with the upstream go-digest package. These are located in a directory with a separate go.mod to avoid affecting the main package.

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
$ go test -bench=. -benchmem .
goos: linux
goarch: amd64
pkg: github.com/sudo-bmitch/oci-digest/testing
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkFromBytes/digest-8              1995490               626.9 ns/op           328 B/op          5 allocs/op
BenchmarkFromBytes/upstream-8            2039294               636.9 ns/op           328 B/op          5 allocs/op
BenchmarkParse/digest-8                 16549548                69.85 ns/op            0 B/op          0 allocs/op
BenchmarkParse/upstream-8                1740939               688.3 ns/op             0 B/op          0 allocs/op
BenchmarkDigester/digest-8               2177174               606.4 ns/op           328 B/op          5 allocs/op
BenchmarkDigester/upstream-8             1868420               607.1 ns/op           360 B/op          6 allocs/op
BenchmarkJSON/digest-marshal-v1-8         332239              3383 ns/op            1913 B/op         32 allocs/op
BenchmarkJSON/upstream-marshal-v1-8      1000000              1221 ns/op             792 B/op          2 allocs/op
BenchmarkJSON/digest-marshal-v2-8         444772              2651 ns/op            1264 B/op         24 allocs/op
BenchmarkJSON/upstream-marshal-v2-8      1000000              1344 ns/op             944 B/op          4 allocs/op
BenchmarkJSON/digest-unmarshal-v1-8       143908              7371 ns/op            3088 B/op         18 allocs/op
BenchmarkJSON/upstream-unmarshal-v1-8              92860             12758 ns/op            1472 B/op         18 allocs/op
BenchmarkJSON/digest-unmarshal-v2-8               325586              3656 ns/op            3065 B/op         17 allocs/op
BenchmarkJSON/upstream-unmarshal-v2-8             122746              9219 ns/op             649 B/op          7 allocs/op
PASS
ok      github.com/sudo-bmitch/oci-digest/testing       16.803s
```

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Add benchmark tests.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
- [X] All changes have been human generated or created with a reproducible tool

<!-- markdownlint-disable-file MD041 -->
